### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -7,6 +7,9 @@ on:
       - .github/workflows/checks.yaml
       - .github/workflows/license-check.yaml
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/G-Core/gcore-videoplayer-js/security/code-scanning/1](https://github.com/G-Core/gcore-videoplayer-js/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/checks.yaml` so all jobs in this workflow (including reusable-workflow calls) inherit least-privilege defaults unless explicitly overridden.

Best single fix without changing functionality:
- Insert at workflow root (after `on:` block, before `jobs:`):
  - `permissions:`
  - `contents: read`

This satisfies CodeQL’s minimal recommendation and supports current visible behavior (`actions/checkout` needs `contents: read`). No imports/dependencies/methods are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
