### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,9 @@
 name: Release
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/G-Core/gcore-videoplayer-js/security/code-scanning/5](https://github.com/G-Core/gcore-videoplayer-js/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/release.yaml` to enforce least privilege for all jobs in this workflow by default.  
The best minimal, non-breaking fix is to set:

- `contents: read`
- `packages: read`

at the workflow root (after `name` and before `on`), which matches GitHub’s recommended minimal read-only baseline and satisfies CodeQL’s requirement for explicit token permission restriction without changing current workflow behavior.

No imports, methods, or external dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
