### PR TITLE
chore(toolkit): update Doctor bootstrap

### DIFF
--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -92,7 +92,6 @@ jobs:
       analyze_day: ${{ steps.collect.outputs.analyze_day }}
       report_tz: ${{ steps.collect.outputs.report_tz }}
       observed_findings_present: ${{ steps.collect.outputs.observed_findings_present }}
-      findings_artifact_name: ${{ steps.collect.outputs.findings_artifact_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -128,7 +127,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.collect.outputs.findings_artifact_name }}
+          name: doctor-findings
           path: ${{ runner.temp }}/doctor/doctor-findings.json
           if-no-files-found: error
 
@@ -149,7 +148,7 @@ jobs:
       - name: Download doctor-findings artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.collect.outputs.findings_artifact_name }}
+          name: doctor-findings
           path: ${{ runner.temp }}/doctor-findings
 
       - name: Checkout toolkit source
@@ -214,7 +213,7 @@ jobs:
       report_tz: ${{ needs.collect.outputs.report_tz }}
       issues_enabled: ${{ github.event.repository.has_issues && 'true' || 'false' }}
       observed_findings_present: ${{ needs.collect.outputs.observed_findings_present }}
-      findings_artifact_name: ${{ needs.collect.outputs.findings_artifact_name }}
+      findings_artifact_name: doctor-findings
       source_sha: ${{ needs.collect.outputs.source_sha }}
       installed_source_sha: ${{ needs.collect.outputs.installed_source_sha }}
       installed_runtime_sha: ${{ needs.collect.outputs.installed_runtime_sha }}
@@ -250,7 +249,7 @@ jobs:
       report_tz: ${{ needs.collect.outputs.report_tz }}
       issues_enabled: ${{ github.event.repository.has_issues && 'true' || 'false' }}
       observed_findings_present: ${{ needs.collect.outputs.observed_findings_present }}
-      findings_artifact_name: ${{ needs.collect.outputs.findings_artifact_name }}
+      findings_artifact_name: doctor-findings
       source_sha: ${{ needs.collect.outputs.source_sha }}
       installed_source_sha: ${{ needs.collect.outputs.installed_source_sha }}
       installed_runtime_sha: ${{ needs.collect.outputs.installed_runtime_sha }}


### PR DESCRIPTION
## Summary

- Replace the old Doctor workflow bootstrap with the current standard bootstrap from G-Core/agent-toolkit
- Use the stable doctor-findings artifact name
- Remove dynamic findings_artifact_name job output usage
- Keep Doctor runtime refs on doctor-v1

## Context

I only have READ permission on this repository, so this PR comes from a fork. The latest scheduled Doctor run failed; job details were not visible through gh run view in the current token context.

## Checks

- git diff --check
- verified doctor-findings is present
- verified dynamic findings_artifact_name output references are absent
- verified doctor-v1 refs are preserved