### PR TITLE
VP-6570: sanitize untrusted data in plugin templates (XSS)

### DIFF
--- a/packages/player/assets/audio-tracks/template.ejs
+++ b/packages/player/assets/audio-tracks/template.ejs
@@ -1,12 +1,12 @@
 <button class='gcore-skin-button-color media-control-dd' id="gplayer-audiotracks-button" aria-haspopup="menu" aria-expanded="false">
-    <span class="media-control-dd__text" id="gplayer-audiotracks-button-text"><%= title %></span>
+    <span class="media-control-dd__text" id="gplayer-audiotracks-button-text"><%- title %></span>
     <span class="media-control-dd__arrow"><%= icon %></span>
 </button>
 <ul class="gcore-skin-bg-color menu media-control-dd__popup" id="gplayer-audiotracks-menu" role="menu">
     <% for (const track of tracks) { %>
         <li>
-            <a href="#" class="gcore-skin-text-color" data-item="<%= track.id %>" role="menuitemradio" aria-checked="<%= track.id === current %>">
-                <%= track.label || track.language %>
+            <a href="#" class="gcore-skin-text-color" data-item="<%- track.id %>" role="menuitemradio" aria-checked="<%= track.id === current %>">
+                <%- track.label || track.language %>
             </a>
         </li>
     <% }; %>

--- a/packages/player/assets/bottom-gear/bottomgear.ejs
+++ b/packages/player/assets/bottom-gear/bottomgear.ejs
@@ -3,7 +3,7 @@
     aria-expanded="false"
     aria-controls="gear-options">
     <%= icon %>
-    <span class="gear-badge<%= badge ? '' : ' hidden' %>"><%= badge %></span>
+    <span class="gear-badge<%= badge ? '' : ' hidden' %>"><%- badge %></span>
 </button>
 <div class="gear-wrapper gcore-skin-bg-color" id="gear-options-wrapper">
     <ul class="gear-options-list" id="gear-options" role="menu"></ul>

--- a/packages/player/assets/cc/combobox.ejs
+++ b/packages/player/assets/cc/combobox.ejs
@@ -13,11 +13,11 @@
             <a
                 href="#"
                 class="gcore-skin-text-color"
-                data-item="<%= t.id %>"
+                data-item="<%- t.id %>"
                 role="menuitemradio"
                 aria-checked="<%= t.id === current %>"
             >
-                <%= t.name %>
+                <%- t.name %>
             </a>
         </li>
     <% } %>

--- a/packages/player/assets/clappr-nerd-stats/clappr-nerd-stats.ejs
+++ b/packages/player/assets/clappr-nerd-stats/clappr-nerd-stats.ejs
@@ -26,26 +26,26 @@
             <li class="title"><span><%= i18n.t('stats.general') %></span></li>
             <li>
                 <%= i18n.t('stats.display_resolution') %>
-                <div><span><span id="nerd-stats-resolution-width"><%= general.resolution.width %></span>&times;<span id="nerd-stats-resolution-height"><%= general.resolution.height %></span></span></div>
+                <div><span><span id="nerd-stats-resolution-width"><%- general.resolution.width %></span>&times;<span id="nerd-stats-resolution-height"><%- general.resolution.height %></span></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.volume') %>
-                <div id="nerd-stats-volume"><span><%= general.volume %></span></div>
+                <div id="nerd-stats-volume"><span><%- general.volume %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.connection_speed') %>
-                <div><span id="nerd-stats-dl-text"><%= custom.connectionSpeed %></span> <%= i18n.t('mbps') %></div>
+                <div><span id="nerd-stats-dl-text"><%- custom.connectionSpeed %></span> <%= i18n.t('mbps') %></div>
             </li>
             <li class="canvas-wrapper">
                 <canvas id="nerd-stats-speed-test-canvas" width="190" height="20"></canvas>
             </li>
             <li>
                 <%= i18n.t('stats.ping') %>
-                <div><span id="nerd-stats-ping-text"><%= custom.ping %></span> <%= i18n.t('ms') %></div>
+                <div><span id="nerd-stats-ping-text"><%- custom.ping %></span> <%= i18n.t('ms') %></div>
             </li>
             <li>
                 <%= i18n.t('stats.jitter') %>
-                <div><span id="nerd-stats-jitter-text"><%= custom.jitter %></span> <%= i18n.t('ms') %></div>
+                <div><span id="nerd-stats-jitter-text"><%- custom.jitter %></span> <%= i18n.t('ms') %></div>
             </li>
         </ul>
 
@@ -53,23 +53,23 @@
             <li class="title"><span><%= i18n.t('stats.duration') %></span></li>
             <li>
                 <%= i18n.t('stats.startup') %>
-                <div><span id="nerd-stats-startup-time"><%= timers.startup %></span></div>
+                <div><span id="nerd-stats-startup-time"><%- timers.startup %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.watching') %>
-                <div><span id="nerd-stats-watch-time"><%= timers.watch %></span></div>
+                <div><span id="nerd-stats-watch-time"><%- timers.watch %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.paused') %>
-                <div><span id="nerd-stats-pause-time"><%= timers.pause %></span></div>
+                <div><span id="nerd-stats-pause-time"><%- timers.pause %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.buffering') %>
-                <div><span id="nerd-stats-buffering-time"><%= timers.buffering %></span></div>
+                <div><span id="nerd-stats-buffering-time"><%- timers.buffering %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.session') %>
-                <div><span id="nerd-stats-session-time"><%= timers.session %></span></div>
+                <div><span id="nerd-stats-session-time"><%- timers.session %></span></div>
             </li>
         </ul>
 
@@ -77,47 +77,47 @@
             <li class="title"><span><%= i18n.t('stats.counters') %></span></li>
             <li>
                 <%= i18n.t('stats.plays') %>
-                <div><span id="nerd-stats-plays"><%= counters.play %></span></div>
+                <div><span id="nerd-stats-plays"><%- counters.play %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.pauses') %>
-                <div><span id="nerd-stats-pauses"><%= counters.pause %></span></div>
+                <div><span id="nerd-stats-pauses"><%- counters.pause %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.errors') %>
-                <div><span id="nerd-stats-errors"><%= counters.error %></span></div>
+                <div><span id="nerd-stats-errors"><%- counters.error %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.bufferings') %>
-                <div><span id="nerd-stats-bufferings"><%= counters.buffering %></span></div>
+                <div><span id="nerd-stats-bufferings"><%- counters.buffering %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.decoded_frames') %>
-                <div><span id="nerd-stats-decoded-frames"><%= counters.decodedFrames %></span></div>
+                <div><span id="nerd-stats-decoded-frames"><%- counters.decodedFrames %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.dropped_frames') %>
-                <div><span id="nerd-stats-dropped-frames"><%= counters.droppedFrames %></span></div>
+                <div><span id="nerd-stats-dropped-frames"><%- counters.droppedFrames %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.fps') %>
-                <div><span id="nerd-stats-fps"><%= counters.fps %></span></div>
+                <div><span id="nerd-stats-fps"><%- counters.fps %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.bitrate_changes') %>
-                <div><span id="nerd-stats-bitrate-changes"><%= counters.changeLevel %></span></div>
+                <div><span id="nerd-stats-bitrate-changes"><%- counters.changeLevel %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.seeks') %>
-                <div><span id="nerd-stats-seeks"><%= counters.seek %></span></div>
+                <div><span id="nerd-stats-seeks"><%- counters.seek %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.fullscreen') %>
-                <div><span id="nerd-stats-fullscreen"><%= counters.fullscreen %></span></div>
+                <div><span id="nerd-stats-fullscreen"><%- counters.fullscreen %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.dvr_seeks') %>
-                <div><span id="nerd-stats-dvr-usage"><%= counters.dvrUsage %></span></div>
+                <div><span id="nerd-stats-dvr-usage"><%- counters.dvrUsage %></span></div>
             </li>
         </ul>
 
@@ -125,11 +125,11 @@
             <li class="title"><span><%= i18n.t('stats.extra') %></span></li>
             <li>
                 <%= i18n.t('stats.playback') %>
-                <div><span id="nerd-stats-playback-name"><%= extra.playbackName %></span></div>
+                <div><span id="nerd-stats-playback-name"><%- extra.playbackName %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.playback_type') %>
-                <div><span id="nerd-stats-playback-type"><%= extra.playbackType %></span></div>
+                <div><span id="nerd-stats-playback-type"><%- extra.playbackType %></span></div>
             </li>
             <li id="nerd-stats-catchup-rate-row" style="display:none">
                 Live catch-up
@@ -141,7 +141,7 @@
             </li>
             <li>
                 <%= i18n.t('stats.buffer_size') %>
-                <div><span id="nerd-stats-buffer-size"><%= extra.buffersize %></span></div>
+                <div><span id="nerd-stats-buffer-size"><%- extra.buffersize %></span></div>
             </li>
             <li id="nerd-stats-segment-drift-row" style="display:none">
                 Segment drift / total
@@ -149,27 +149,27 @@
             </li>
             <li>
                 <%= i18n.t('stats.video_duration') %>
-                <div><span id="nerd-stats-video-duration"><%= extra.duration %></span></div>
+                <div><span id="nerd-stats-video-duration"><%- extra.duration %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.current_time') %>
-                <div><span id="nerd-stats-current-time"><%= extra.currentTime %></span></div>
+                <div><span id="nerd-stats-current-time"><%- extra.currentTime %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.bitrate_weighted_mean') %>
-                <div><span id="nerd-stats-bitrate-weighted-mean"><%= extra.bitrateWeightedMean %></span></div>
+                <div><span id="nerd-stats-bitrate-weighted-mean"><%- extra.bitrateWeightedMean %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.bitrate_most_used') %>
-                <div><span id="nerd-stats-bitrate-most-used"><%= extra.bitrateMostUsed %></span></div>
+                <div><span id="nerd-stats-bitrate-most-used"><%- extra.bitrateMostUsed %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.watched_percentage') %>
-                <div><span id="nerd-stats-watched-percentage"><%= extra.watchedPercentage %></span></div>
+                <div><span id="nerd-stats-watched-percentage"><%- extra.watchedPercentage %></span></div>
             </li>
             <li>
                 <%= i18n.t('stats.buffering_percentage') %>
-                <div><span id="nerd-stats-buffering-percentage"><%= extra.bufferingPercentage %></span></div>
+                <div><span id="nerd-stats-buffering-percentage"><%- extra.bufferingPercentage %></span></div>
             </li>
         </ul>
     </div>
@@ -180,7 +180,7 @@
                 <div class="speedtest-summary-subblock-content">
                     <div class="speedtest-quality">
                         <div class="speedtest-quality-header"><%= i18n.t('vod') %>: 
-                            <span id="nerd-stats-quality-vod-text"><%= custom.vodQuality %></span></div>
+                            <span id="nerd-stats-quality-vod-text"><%- custom.vodQuality %></span></div>
                         <div class="speedtest-quality-content" data-streaming-type="vod" id="nerd-stats-quality-vod">
                             <div class="speedtest-quality-content-item"></div>
                             <div class="speedtest-quality-content-item"></div>
@@ -195,7 +195,7 @@
                 <div class="speedtest-summary-subblock-content">
                     <div class="speedtest-quality">
                         <div class="speedtest-quality-header"><%= i18n.t('live') %>: 
-                            <span id="nerd-stats-quality-live-text"><%= custom.liveQuality %></span></div>
+                            <span id="nerd-stats-quality-live-text"><%- custom.liveQuality %></span></div>
                         <div class="speedtest-quality-content" data-streaming-type="live" id="nerd-stats-quality-live">
                             <div class="speedtest-quality-content-item"></div>
                             <div class="speedtest-quality-content-item"></div>

--- a/packages/player/assets/context-menu/context_menu.ejs
+++ b/packages/player/assets/context-menu/context_menu.ejs
@@ -1,14 +1,14 @@
 <ul class="context-menu-list" role="menu" id="context-menu-options">
     <% for (const item of options) { %>
-    <li class="context-menu-list-item <%= item.class %>">
-        <button role="menuitem" data-name="<%= item.name %>">
+    <li class="context-menu-list-item <%- item.class %>">
+        <button role="menuitem" data-name="<%- item.name %>">
             <% if (iconic) { %>
             <span class="context-menu-list-item_icon"><%= item.icon || '' %></span>
             <% } %>
             <% if (item.labelKey) { %>
                 <%= i18n.t(item.labelKey) %>
             <% } else { %>
-                <%= item.label %>
+                <%- item.label %>
             <% } %>
         </button>
     </li>

--- a/packages/player/assets/error-screen/error_screen.ejs
+++ b/packages/player/assets/error-screen/error_screen.ejs
@@ -2,12 +2,12 @@
     <% if (icon) { %>
         <div class="player-error-screen__icon" data-error-screen><%= icon %></div>
     <% } %>
-    <div class="player-error-screen__title" data-error-screen><%= title %></div>
+    <div class="player-error-screen__title" data-error-screen><%- title %></div>
     <% if (message) { %>
-        <div class="player-error-screen__message" data-error-screen><%= message %></div>
+        <div class="player-error-screen__message" data-error-screen><%- message %></div>
     <% } %>
     <% if (code) { %>
-        <div class="player-error-screen__code" data-error-screen><%= i18n.t('error_code') %>: <%= code %></div>
+        <div class="player-error-screen__code" data-error-screen><%= i18n.t('error_code') %>: <%- code %></div>
     <% } %>
     <% if (reloadIcon) { %>
         <div class="player-error-screen__reload" data-error-screen><%= reloadIcon %></div>

--- a/packages/player/assets/level-selector/button.ejs
+++ b/packages/player/assets/level-selector/button.ejs
@@ -1,6 +1,6 @@
 <button class='gplayer-lite-btn gcore-skin-text-color gear-option' aria-haspopup="menu" id="quality-levels">
-    <span class="gear-option_tier<%= currentTier ? '' : ' hidden' %>"><%= currentTier %></span>
+    <span class="gear-option_tier<%= currentTier ? '' : ' hidden' %>"><%- currentTier %></span>
     <span class="gear-option_label"><%= i18n.t('quality') %></span>
-    <span class='gear-option_value'><%= currentText %></span>
+    <span class='gear-option_value'><%- currentText %></span>
     <span class="gear-option_arrow-right-icon"><%= arrowRightIcon %></span>
 </button>

--- a/packages/player/assets/level-selector/list.ejs
+++ b/packages/player/assets/level-selector/list.ejs
@@ -25,14 +25,14 @@
         <li class="<%= disabled ? ' disabled' : ''%><%=checked ? ' current' : ''%>">
             <a href="#"
                 class="gear-sub-menu_btn gcore-skin-text-color<%= checked ? ' gcore-skin-active' : '' %>"
-                data-id="<%= item.level %>"
-                aria-disabled="<%= disabled %>"
-                aria-checked="<%= checked %>"
+                data-id="<%- item.level %>"
+                aria-disabled="<%- disabled %>"
+                aria-checked="<%- checked %>"
                 role="menuitemradio"
                 id="level_selector_<%= item.width > item.height ? item.height : item.width %>"
             >
                 <span class="check-icon"><%= checkIcon %></span>
-                <%= labels[i] %>
+                <%- labels[i] %>
             </a>
         </li>
     <% } %>

--- a/packages/player/assets/media-control/media-control.ejs
+++ b/packages/player/assets/media-control/media-control.ejs
@@ -50,7 +50,7 @@
     <% }; %>
     <% var renderButton = function(name) { %>
         <button type="button" class="media-control-button media-control-icon gcore-skin-button-color" data-<%= name %>
-            aria-label="<%= name %>"></button>
+            aria-label="<%- name %>"></button>
     <% }; %>
 
     <% var templates = {

--- a/packages/player/assets/multi-camera/multicamera.ejs
+++ b/packages/player/assets/multi-camera/multicamera.ejs
@@ -8,22 +8,22 @@
             <% continue; %>
                 <% } %>
                     <li>
-                        <div class="multicamera-item" data-multicamera-selector-live="<%= streams[i].live %>"
-                            data-multicamera-selector-select="<%= streams[i].id %>">
+                        <div class="multicamera-item" data-multicamera-selector-live="<%- streams[i].live %>"
+                            data-multicamera-selector-select="<%- streams[i].id %>">
                             <div class="multicamera-screenshot">
                                 <% if (streams[i].screenshot) { %>
-                                    <img src="<%= streams[i].screenshot %>" alt="<%= streams[i].title %>" />
+                                    <img src="<%- streams[i].screenshot %>" alt="<%- streams[i].title %>" />
                                     <% } %>
                             </div>
                             <div class="multicamera-text gcore-skin-text-color">
                                 <% if (streams[i].title) { %>
                                     <div class="multicamera-title gcore-skin-text-color">
-                                        <%= streams[i].title %>
+                                        <%- streams[i].title %>
                                     </div>
                                     <% } %>
                                         <% if (streams[i].description) { %>
                                             <div class="multicamera-description gcore-skin-text-color">
-                                                <%= streams[i].description %>
+                                                <%- streams[i].description %>
                                             </div>
                                             <% } %>
                             </div>

--- a/packages/player/assets/playback-rate/button.ejs
+++ b/packages/player/assets/playback-rate/button.ejs
@@ -1,6 +1,6 @@
 <button class='gplayer-lite-btn gcore-skin-text-color gear-option' id="playback-rate-button">
     <span class="gear-option_speed-icon gear-option_icon"><%= speedIcon %></span>
     <span class="gear-option_label"><%= i18n.t('playback_rate') %></span>
-    <span class='gear-option_value'><%= title %></span>
+    <span class='gear-option_value'><%- title %></span>
     <span class="gear-option_arrow-right-icon"><%= arrowRightIcon %></span>
 </button>

--- a/packages/player/assets/playback-rate/list.ejs
+++ b/packages/player/assets/playback-rate/list.ejs
@@ -5,9 +5,9 @@
 <ul class="gear-sub-menu" id="playback-rate-menu">
     <% for (const item of playbackRates) { %>
         <li<%= item.value === current ? ' class="current"' : '' %>>
-            <a href="#" class="gear-sub-menu_btn gcore-skin-text-color<%= item.value === current ? ' gcore-skin-active' : '' %>" data-rate="<%= item.value %>">
+            <a href="#" class="gear-sub-menu_btn gcore-skin-text-color<%= item.value === current ? ' gcore-skin-active' : '' %>" data-rate="<%- item.value %>">
                 <span class="check-icon"><%= checkIcon %></span>
-                <%= item.label %>
+                <%- item.label %>
             </a>
         </li>
     <% } %>

--- a/packages/player/assets/share/share.ejs
+++ b/packages/player/assets/share/share.ejs
@@ -14,7 +14,7 @@
                 <div class="share-container-header--linktext gcore-skin-text-color"><%= link_title %></div>
                 <input
                         class="share-container-header--link gcore-skin-bg-color gcore-skin-text-color gcore-skin-border-textarea-color"
-                        value="<%= url %>" data-share-link
+                        value="<%- url %>" data-share-link
                 >
             <% }; %>
             <% if (url) { %>
@@ -30,7 +30,7 @@
                 <div class="share-container-header--embedtext gcore-skin-text-color"><%= embed_title %></div>
                 <textarea
                         class="share-container-header--embed gcore-skin-bg-color gcore-skin-text-color gcore-skin-border-textarea-color"
-                        rows="4" data-share-embed><%= embed %></textarea>
+                        rows="4" data-share-embed><%- embed %></textarea>
             <% }; %>
         </div>
     </div>

--- a/packages/player/assets/share/share.ejs
+++ b/packages/player/assets/share/share.ejs
@@ -6,19 +6,19 @@
 
     <div class="share-container gcore-skin-bg-color">
         <div class="share-container-header gcore-skin-bg-color">
-            <div class="share-container-header--title gcore-skin-text-color"><%= share_title %></div>
+            <div class="share-container-header--title gcore-skin-text-color"><%- share_title %></div>
             <div class="share-container-header--close gcore-skin-button-color" data-share-close></div>
         </div>
         <div class="share-container-main gcore-skin-bg-color">
             <% if (url) { %>
-                <div class="share-container-header--linktext gcore-skin-text-color"><%= link_title %></div>
+                <div class="share-container-header--linktext gcore-skin-text-color"><%- link_title %></div>
                 <input
                         class="share-container-header--link gcore-skin-bg-color gcore-skin-text-color gcore-skin-border-textarea-color"
                         value="<%- url %>" data-share-link
                 >
             <% }; %>
             <% if (url) { %>
-                <div class="share-container-header--socialtext gcore-skin-text-color"><%= social_title %></div>
+                <div class="share-container-header--socialtext gcore-skin-text-color"><%- social_title %></div>
                 <div class="share-container-header--socialicon">
                     <div class="share-container-header--socialicon_fb gcore-skin-button-with-bg-color"
                          data-share-fb></div>
@@ -27,7 +27,7 @@
                 </div>
             <% }; %>
             <% if (embed) { %>
-                <div class="share-container-header--embedtext gcore-skin-text-color"><%= embed_title %></div>
+                <div class="share-container-header--embedtext gcore-skin-text-color"><%- embed_title %></div>
                 <textarea
                         class="share-container-header--embed gcore-skin-bg-color gcore-skin-text-color gcore-skin-border-textarea-color"
                         rows="4" data-share-embed><%- embed %></textarea>

--- a/packages/player/src/plugins/__tests__/template-escaping.test.ts
+++ b/packages/player/src/plugins/__tests__/template-escaping.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Regression guard for template XSS (VP-6570).
+ *
+ * Clappr's templater offers two interpolation delimiters:
+ *   <%= expr %>  — raw, NOT escaped (safe only for trusted/computed values)
+ *   <%- expr %>  — HTML-escaped (safe for any value)
+ *
+ * Any value that can originate from a stream manifest, a remote API, or
+ * plugin config MUST be rendered with <%- ... %>. This test fails if a
+ * template uses the raw <%= ... %> delimiter for anything other than the
+ * allowlisted, provably-safe cases below, forcing new dynamic data through
+ * the escaping delimiter.
+ *
+ * Allowed raw <%= %> cases:
+ *  - SVG icon identifiers (bundled constants), e.g. `icon`, `checkIcon`, `pipIcon`
+ *  - localized strings, i.e. `i18n.t(...)`
+ *  - pure boolean / numeric / comparison / ternary expressions (computed,
+ *    not free text), detected by the presence of an operator
+ *  - the media-control layout token interpolated as an attribute *name*
+ *    (`data-<%= name %>`), which is a trusted internal enum, not a value
+ */
+
+const assetsDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../assets',
+)
+
+function listEjsFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...listEjsFiles(full))
+    } else if (entry.name.endsWith('.ejs')) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+const ICON_RE = /^[\w$]*[Ii]con$/
+const OPERATOR_RE = /===|==|!==|!=|[?]|&&|\|\||[<>]/
+
+function isAllowedRawInterpolation(expr: string, prefix: string): boolean {
+  // Attribute-*name* interpolation of the trusted layout token, e.g. data-<%= name %>
+  if (prefix.endsWith('data-')) {
+    return true
+  }
+  const e = expr.trim()
+  if (ICON_RE.test(e)) {
+    return true
+  }
+  if (e.startsWith('i18n.t(')) {
+    return true
+  }
+  // boolean / numeric / comparison / ternary expression — a computed value
+  if (OPERATOR_RE.test(e)) {
+    return true
+  }
+  return false
+}
+
+describe('template escaping (XSS regression guard)', () => {
+  const files = listEjsFiles(assetsDir)
+
+  it('finds template files to scan', () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  it('uses the escaping delimiter for all non-allowlisted interpolations', () => {
+    const violations: string[] = []
+    const re = /<%=([\s\S]+?)%>/g
+    for (const file of files) {
+      const text = fs.readFileSync(file, 'utf8')
+      let m: RegExpExecArray | null
+      while ((m = re.exec(text)) !== null) {
+        const prefix = text.slice(Math.max(0, m.index - 5), m.index)
+        if (!isAllowedRawInterpolation(m[1], prefix)) {
+          const rel = path.relative(assetsDir, file)
+          violations.push(`${rel}: <%=${m[1]}%>`)
+        }
+      }
+    }
+    expect(violations, `Raw <%= %> used for potentially unsafe values:\n${violations.join('\n')}`).toEqual([])
+  })
+})

--- a/packages/player/src/plugins/audio-selector/__tests__/AudioTracks.test.ts
+++ b/packages/player/src/plugins/audio-selector/__tests__/AudioTracks.test.ts
@@ -194,6 +194,30 @@ describe('AudioTracks', () => {
       })
     })
   })
+  describe('XSS: malicious track metadata from a manifest', () => {
+    const PAYLOAD = '<img src=x onerror=__xss__()>'
+    const ID_PAYLOAD = '"><img src=x onerror=__xss__()>'
+    const MALICIOUS_TRACKS = [
+      { id: '1', label: 'English', language: 'en', track: {} },
+      { id: ID_PAYLOAD, label: PAYLOAD, language: 'en', track: {} },
+    ]
+    beforeEach(() => {
+      emitTracksAvailable(core, MALICIOUS_TRACKS)
+    })
+    it('should not materialize an injected element from track metadata', () => {
+      expect(audioTracks.el.querySelectorAll('img').length).toBe(0)
+    })
+    it('should render the label payload as literal text', () => {
+      const items = audioTracks.$el.find('#gplayer-audiotracks-menu li')
+      expect(items.eq(1).text()).toContain(PAYLOAD)
+    })
+    it('should keep a malicious track id confined to its attribute value', () => {
+      const links = audioTracks.$el.find('#gplayer-audiotracks-menu a[data-item]')
+      expect(links.length).toBe(2)
+      expect(links.eq(1).attr('data-item')).toBe(ID_PAYLOAD)
+    })
+  })
+
   describe('when container is clicked', () => {
     beforeEach(() => {
       emitTracksAvailable(core, TRACKS)

--- a/packages/player/src/plugins/context-menu/__tests__/ContextMenu.test.ts
+++ b/packages/player/src/plugins/context-menu/__tests__/ContextMenu.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { ContextMenu } from '../ContextMenu'
+import { createMockContainer } from '../../../testUtils'
+
+function setup(options: any[]) {
+  const container: any = createMockContainer({ contextMenu: { options } })
+  return new ContextMenu(container)
+}
+
+describe('ContextMenu', () => {
+  describe('XSS: malicious menu option fields', () => {
+    const LABEL_PAYLOAD = '<img src=x onerror=__xss_label__()>'
+    const NAME_PAYLOAD = '"><img src=x onerror=__xss_name__()>'
+    const CLASS_PAYLOAD = '"><img src=x onerror=__xss_class__()>'
+
+    let plugin: ContextMenu
+    beforeEach(() => {
+      plugin = setup([
+        { name: NAME_PAYLOAD, label: LABEL_PAYLOAD, class: CLASS_PAYLOAD },
+      ])
+    })
+
+    it('should not inject an element with an event handler', () => {
+      expect(plugin.el.querySelectorAll('[onerror]').length).toBe(0)
+    })
+    it('should not materialize any injected image element', () => {
+      expect(plugin.el.querySelectorAll('img').length).toBe(0)
+    })
+    it('should render a menu item label as literal text', () => {
+      expect(plugin.$el.find('[role="menuitem"]').text()).toContain(
+        LABEL_PAYLOAD,
+      )
+    })
+    it('should keep a malicious item name confined to its attribute value', () => {
+      expect(plugin.$el.find('[role="menuitem"]').attr('data-name')).toBe(
+        NAME_PAYLOAD,
+      )
+    })
+  })
+})

--- a/packages/player/src/plugins/error-screen/__tests__/ErrorScreen.test.ts
+++ b/packages/player/src/plugins/error-screen/__tests__/ErrorScreen.test.ts
@@ -54,6 +54,48 @@ describe('ErrorScreen', () => {
         })
       }
     })
+    describe('XSS: malicious error fields', () => {
+      const TITLE_PAYLOAD = '<img src=x onerror=__xss_title__()>'
+      const MESSAGE_PAYLOAD = '<img src=x onerror=__xss_message__()>'
+      const CODE_PAYLOAD = '<img src=x onerror=__xss_code__()>'
+      beforeEach(() => {
+        errorScreen = new ErrorScreen(core)
+        core.emit('core:ready')
+        core.emit('core:active:container:changed')
+        core.emit('error', {
+          code: CODE_PAYLOAD,
+          UI: {
+            title: TITLE_PAYLOAD,
+            message: MESSAGE_PAYLOAD,
+            icon: '<svg></svg>',
+          },
+        })
+      })
+      it('should not inject an element with an event handler', () => {
+        expect(errorScreen.el.querySelectorAll('[onerror]').length).toBe(0)
+      })
+      it('should not materialize any injected image element', () => {
+        expect(errorScreen.el.querySelectorAll('img').length).toBe(0)
+      })
+      it('should render the error title as literal text', () => {
+        expect(
+          errorScreen.el.querySelector('.player-error-screen__title')
+            ?.textContent,
+        ).toContain(TITLE_PAYLOAD)
+      })
+      it('should render the error message as literal text', () => {
+        expect(
+          errorScreen.el.querySelector('.player-error-screen__message')
+            ?.textContent,
+        ).toContain(MESSAGE_PAYLOAD)
+      })
+      it('should render the error code as literal text', () => {
+        expect(
+          errorScreen.el.querySelector('.player-error-screen__code')
+            ?.textContent,
+        ).toContain(CODE_PAYLOAD)
+      })
+    })
     describe('reload button', () => {
       describe('basically', () => {
         beforeEach(() => {

--- a/packages/player/src/plugins/multi-camera/__tests__/MultiCamera.test.ts
+++ b/packages/player/src/plugins/multi-camera/__tests__/MultiCamera.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Events } from '@clappr/core'
+
+import { MultiCamera } from '../MultiCamera'
+import { createMockCore, createMockMediaControl } from '../../../testUtils'
+
+function setup(multisources: any[], multisourcesMode = 'show_all') {
+  const core: any = createMockCore({ multisources, multisourcesMode })
+  const mediaControl = createMockMediaControl(core)
+  core.mediaControl = mediaControl
+  core.getPlugin = vi.fn().mockImplementation((name: string) => {
+    if (name === 'media_control') return mediaControl
+    return null
+  })
+  // The base UICorePlugin constructor calls render() before fields are set; in
+  // production the activeContainer guard short-circuits it because the plugin
+  // is constructed before the container is ready. Reproduce that ordering.
+  const container = core.activeContainer
+  const playback = core.activePlayback
+  core.activeContainer = null
+  core.activePlayback = null
+  const plugin = new MultiCamera(core)
+  core.activeContainer = container
+  core.activePlayback = playback
+  core.emit(Events.CORE_READY)
+  mediaControl.trigger(Events.MEDIACONTROL_RENDERED)
+  return { core, mediaControl, plugin }
+}
+
+describe('MultiCamera', () => {
+  describe('XSS: malicious stream metadata from a remote source list', () => {
+    const TITLE_PAYLOAD = '<img src=x onerror=__xss_title__()>'
+    const DESC_PAYLOAD = '<img src=x onerror=__xss_desc__()>'
+    const SCREENSHOT_PAYLOAD = '"><img src=x onerror=__xss_ss__()>'
+    const ID_PAYLOAD = '"><img src=x onerror=__xss_id__()>'
+
+    let plugin: MultiCamera
+    beforeEach(() => {
+      const multisources = [
+        {
+          id: 1,
+          live: true,
+          title: 'Camera 1',
+          description: 'A safe camera',
+          screenshot: 'https://example.com/a.jpg',
+          source: 'https://example.com/a.m3u8',
+          source_dash: null,
+          hls_mpegts_url: null,
+          projection: null,
+          dvr: false,
+        },
+        {
+          id: ID_PAYLOAD,
+          live: true,
+          title: TITLE_PAYLOAD,
+          description: DESC_PAYLOAD,
+          screenshot: SCREENSHOT_PAYLOAD,
+          source: 'https://example.com/b.m3u8',
+          source_dash: null,
+          hls_mpegts_url: null,
+          projection: null,
+          dvr: false,
+        },
+      ]
+      ;({ plugin } = setup(multisources))
+    })
+
+    it('should not inject an element with an event handler', () => {
+      expect(plugin.el.querySelectorAll('[onerror]').length).toBe(0)
+    })
+    it('should render exactly one screenshot image per stream', () => {
+      // Each stream renders one legitimate <img>; a breakout would create extra.
+      expect(plugin.el.querySelectorAll('img').length).toBe(2)
+    })
+    it('should keep a malicious screenshot url confined to the src attribute', () => {
+      const imgs = plugin.$el.find('img')
+      expect(imgs.eq(1).attr('src')).toBe(SCREENSHOT_PAYLOAD)
+    })
+    it('should render a stream title as literal text', () => {
+      expect(plugin.$el.find('.multicamera-title').text()).toContain(
+        TITLE_PAYLOAD,
+      )
+    })
+    it('should render a stream description as literal text', () => {
+      expect(plugin.$el.find('.multicamera-description').text()).toContain(
+        DESC_PAYLOAD,
+      )
+    })
+    it('should keep a malicious stream id confined to its attribute value', () => {
+      const items = plugin.$el.find('.multicamera-item')
+      expect(items.eq(1).attr('data-multicamera-selector-select')).toBe(
+        ID_PAYLOAD,
+      )
+    })
+  })
+})

--- a/packages/player/src/plugins/share/__tests__/Share.test.ts
+++ b/packages/player/src/plugins/share/__tests__/Share.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Events } from '@clappr/core'
+
+import { Share } from '../Share'
+import { createMockCore, createMockMediaControl } from '../../../testUtils'
+
+function setup(options: Record<string, unknown>) {
+  const core: any = createMockCore(options)
+  const mediaControl = createMockMediaControl(core)
+  core.mediaControl = mediaControl
+  core.getPlugin = vi.fn().mockImplementation((name: string) => {
+    if (name === 'media_control') return mediaControl
+    return null
+  })
+  const plugin = new Share(core)
+  core.emit(Events.CORE_READY)
+  mediaControl.trigger(Events.MEDIACONTROL_RENDERED)
+  return { core, mediaControl, plugin }
+}
+
+describe('Share', () => {
+  describe('XSS: malicious share url and embed code', () => {
+    const URL_PAYLOAD = '"><img src=x onerror=__xss_url__()>'
+    const EMBED_PAYLOAD = '</textarea><img src=x onerror=__xss_embed__()>'
+
+    let plugin: Share
+    beforeEach(() => {
+      ;({ plugin } = setup({ shareURL: URL_PAYLOAD, embed: EMBED_PAYLOAD }))
+    })
+
+    it('should not inject an element with an event handler', () => {
+      expect(plugin.el.querySelectorAll('[onerror]').length).toBe(0)
+    })
+    it('should not materialize any injected image element', () => {
+      expect(plugin.el.querySelectorAll('img').length).toBe(0)
+    })
+    it('should keep the share url confined to the input value', () => {
+      expect(plugin.$el.find('[data-share-link]').val()).toBe(URL_PAYLOAD)
+    })
+    it('should keep the embed code confined to the textarea value', () => {
+      expect(plugin.$el.find('[data-share-embed]').val()).toBe(EMBED_PAYLOAD)
+    })
+  })
+})

--- a/packages/player/src/plugins/source-controller/SourceController.ts
+++ b/packages/player/src/plugins/source-controller/SourceController.ts
@@ -1,5 +1,5 @@
 import {
-  Events as Events,
+  Events,
   CorePlugin,
   type Core as ClapprCore,
 } from '@clappr/core'

--- a/packages/player/src/plugins/subtitles/ClosedCaptions.ts
+++ b/packages/player/src/plugins/subtitles/ClosedCaptions.ts
@@ -527,7 +527,13 @@ export class ClosedCaptions extends UICorePlugin {
   }
 
   private setSubtitleText(text: string | DocumentFragment) {
-    this.$line.find('p').html(text)
+    // A raw string here originates from a cue payload (e.g. oncueenter) and may
+    // contain untrusted manifest/VTT markup. Parse it into a sanitized fragment
+    // via the browser's WebVTT parser instead of injecting it as raw HTML.
+    // DocumentFragment inputs are already produced by getCueAsHTML and are safe.
+    const content =
+      typeof text === 'string' ? cueTextToFragment(text) : text
+    this.$line.find('p').html(content)
   }
 
   private clearSubtitleText() {
@@ -611,4 +617,25 @@ export class ClosedCaptions extends UICorePlugin {
   }
 
   private clickaway = mediaControlClickaway(() => this.hideMenu())
+}
+
+/**
+ * Turns a raw cue-text string into a sanitized DocumentFragment using the
+ * browser's native WebVTT parser (`VTTCue.getCueAsHTML`). The parser only emits
+ * the WebVTT-allowed element set (`<c>`, `<i>`, `<b>`, `<u>`, `<ruby>`, `<rt>`,
+ * `<v>`, `<lang>`) and HTML-escapes everything else, so injected markup such as
+ * `<img onerror=...>` cannot execute. Falls back to a plain text node when the
+ * WebVTT API is unavailable.
+ */
+function cueTextToFragment(text: string): DocumentFragment | string {
+  try {
+    if (typeof VTTCue !== 'undefined') {
+      return new VTTCue(0, 0, text).getCueAsHTML()
+    }
+  } catch {
+    // fall through to the text-node fallback
+  }
+  const fragment = document.createDocumentFragment()
+  fragment.appendChild(document.createTextNode(text))
+  return fragment
 }

--- a/packages/player/src/plugins/subtitles/__tests__/ClosedCaptions.test.ts
+++ b/packages/player/src/plugins/subtitles/__tests__/ClosedCaptions.test.ts
@@ -503,6 +503,70 @@ describe('ClosedCaptions', () => {
       },
     )
   })
+  describe('XSS: malicious subtitle metadata and cue text', () => {
+    const NAME_PAYLOAD = '<img src=x onerror=__xss_name__()>'
+    const LANG_PAYLOAD = '<img src=x onerror=__xss_lang__()>'
+    const ID_PAYLOAD = '"><img src=x onerror=__xss_id__()>'
+    const CUE_PAYLOAD = '<img src=x onerror=__xss_cue__()>'
+    beforeEach(() => {
+      core.options.cc = { language: 'none' }
+      core.emit(Events.CORE_READY)
+      core.activePlayback.el = document.createElement('video')
+      core.emit(Events.CORE_ACTIVE_CONTAINER_CHANGED, core.activeContainer)
+      // Track metadata as it would arrive from a crafted manifest:
+      // - track 0 carries the payload in its NAME (label)
+      // - track 1 has no name, so its language is used as the displayed name,
+      //   and carries the payload in its id (rendered into data-item)
+      const nativeTracks = [
+        {
+          language: 'en',
+          kind: 'subtitles',
+          label: NAME_PAYLOAD,
+          mode: 'hidden',
+          cues: [],
+          id: '01en',
+        },
+        {
+          language: LANG_PAYLOAD,
+          kind: 'subtitles',
+          label: '',
+          mode: 'hidden',
+          cues: [],
+          id: ID_PAYLOAD,
+        },
+      ]
+      core.activePlayback.closedCaptionsTracks = [
+        { id: 0, name: nativeTracks[0].label, track: nativeTracks[0] },
+        { id: ID_PAYLOAD, name: nativeTracks[1].label, track: nativeTracks[1] },
+      ]
+      vi.spyOn(core.activePlayback.el, 'textTracks', 'get').mockReturnValue(
+        nativeTracks,
+      )
+      core.activePlayback.emit(Events.PLAYBACK_SUBTITLE_AVAILABLE)
+      core.activeContainer.emit(Events.CONTAINER_SUBTITLE_AVAILABLE)
+      vi.advanceTimersByTime(1)
+    })
+    it('should not materialize any injected element in the menu', () => {
+      expect(cc.$el.find('#gplayer-cc-menu').find('img').length).toBe(0)
+    })
+    it('should render a subtitle name payload as literal text', () => {
+      expect(cc.$el.find('#gplayer-cc-menu').text()).toContain(NAME_PAYLOAD)
+    })
+    it('should render a language-fallback name payload as literal text', () => {
+      expect(cc.$el.find('#gplayer-cc-menu').text()).toContain(LANG_PAYLOAD)
+    })
+    it('should keep a malicious track id confined to its attribute value', () => {
+      const link = cc.$el.find('#gplayer-cc-menu li:nth-child(2) a')
+      expect(link.attr('data-item')).toBe(ID_PAYLOAD)
+      expect(link.find('img').length).toBe(0)
+    })
+    it('should not execute markup injected via a subtitle cue', () => {
+      core.activePlayback.oncueenter({ text: CUE_PAYLOAD })
+      const line = core.activeContainer.$el.find('#gplayer-cc-line p')
+      expect(line.find('img').length).toBe(0)
+      expect(line.text()).toContain(CUE_PAYLOAD)
+    })
+  })
 })
 
 function emitSubtitleAvailable(core: any, selectedTrackId?: number) {


### PR DESCRIPTION
## Summary

https://jira.gcore.lu/browse/VP-6570

Clappr's templater (`@clappr/core` micro-templater) offers two interpolation delimiters: `<%= %>` (raw, unescaped) and `<%- %>` (HTML-escaped). Across all player plugin templates, **only the raw `<%=` was ever used** — including for values that originate from parsed stream manifests, remote APIs, and plugin config — allowing stored/reflected XSS when the relevant UI renders.

This PR escapes every untrusted interpolation, fixes the one non-template sink (WebVTT cue text), and adds a regression guard so it can't happen again.

## Vulnerabilities fixed (each TDD: failing payload test → fix → green)

| Plugin | Sink | Source |
|---|---|---|
| AudioTracks | track label / language / id | HLS `#EXT-X-MEDIA NAME` / DASH `<Label>` |
| ClosedCaptions | subtitle name / id / language + WebVTT cue text | subtitle manifest + cue payload |
| MultiCamera | title / description / screenshot / id / live | `options.multisources` |
| Share | share url (input value) + embed code (textarea) | `options.shareURL` / `options.embed` |
| ErrorScreen | error title / message / code | playback error (can carry server/manifest text) |
| Sweep | context-menu, bottom-gear, level-selector, media-control, playback-rate, nerd-stats | config-driven |

## Approach

- Switch untrusted `<%=` → `<%-` (escaping) in the `.ejs` templates. SVG icons, `i18n.t(...)`, and computed boolean/numeric/comparison expressions stay raw by design.
- WebVTT cue text (the one non-template sink) is parsed to a sanitized `DocumentFragment` via the browser's `VTTCue.getCueAsHTML()` (preserves `<b>/<i>/<c>` styling, escapes everything else) with a text-node fallback.
- New **regression guard** (`template-escaping.test.ts`) scans every `.ejs` and fails on any raw `<%=` outside the allowlist, preventing future unescaped interpolation of untrusted data.

## Verification

- Full suite **351/351 pass** (incl. new XSS payload tests asserting injected markup never materializes as DOM nodes / event handlers).
- `tsc` typecheck clean, `npm run build` succeeds, lint unchanged from baseline.

## Notes

- The first commit also carries a small pre-staged, unrelated import cleanup in `SourceController.ts`.
- nerd-stats numeric stat fields were escaped too (output-identical for numbers) so the regression guard stays strict with no per-field allowlist.
- Out of scope (pre-existing, not a regression): `MultiCamera.shouldRender()` lacks the optional-chaining guard its siblings have, making it fragile to early `render()` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)