### PR TITLE
VP-6582 Cease use of ua-parser-js

### DIFF
--- a/packages/player/package-lock.json
+++ b/packages/player/package-lock.json
@@ -12,14 +12,14 @@
         "@clappr/core": "^0.13.0",
         "@gcorevideo/utils": "^0.7.1",
         "@sentry/types": "^8.47.0",
-        "dashjs": "^5.1.1",
+        "dashjs": "^5.2.0",
         "hls.js": "^1.6.15",
         "human-format": "^1.2.1",
         "mousetrap": "^1.6.5",
         "videojs-vtt.js": "^0.15.5"
       },
       "devDependencies": {
-        "@microsoft/api-documenter": "^7.26.5",
+        "@microsoft/api-documenter": "^7.30.7",
         "@microsoft/api-extractor": "^7.49.1",
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-json": "^6.1.0",
@@ -1595,110 +1595,110 @@
       }
     },
     "node_modules/@svta/cml-608": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-608/-/cml-608-1.0.1.tgz",
-      "integrity": "sha512-Y/Ier9VPUSOBnf0bJqdDyTlPrt4dDB+jk5mYHa1bnD2kcRl8qn7KkW3PRuj4w1aVN+BS2eHmsLxodt7P2hylUg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@svta/cml-608/-/cml-608-1.0.2.tgz",
+      "integrity": "sha512-ZEJ68330gcLKfvVv6Qifr1HR7+GldDUxzkjqSbqRK7jHtHSLSV1JAyDwlYe8+C7ABuY1bp8MpgJ4/Gg+jl+pLQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@svta/cml-cmcd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-cmcd/-/cml-cmcd-1.0.1.tgz",
-      "integrity": "sha512-eox305g+QUJgXqOLVrbgxeQHCgl90ewwQ9O2bIoo7m+hanR8Xswu5CknFnT5qqIbLOHfw80ug+raycoAFHTQ+w==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@svta/cml-cmcd/-/cml-cmcd-2.3.2.tgz",
+      "integrity": "sha512-SKBBjLmci0WK8HMjuv+36tVIMktonoOoxsXblOFZmB+ePPV2zjRMTD+2ZmE/1VEPJkKHENyhSjSHgJyeOlvZ1A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@svta/cml-cta": "1.0.1",
-        "@svta/cml-structured-field-values": "1.0.1",
-        "@svta/cml-utils": "1.0.1"
+        "@svta/cml-structured-field-values": "1.1.3",
+        "@svta/cml-utils": "1.5.0"
       }
     },
     "node_modules/@svta/cml-cmsd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-cmsd/-/cml-cmsd-1.0.1.tgz",
-      "integrity": "sha512-+nIB8PuSfb/qw+xGaArPhNqPm84tBJUbe3H1DnPL5QUsjSUI7mUIUQwAtRV1ZdEu0+80g9i0op79woB0OIwr/g==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-cmsd/-/cml-cmsd-1.0.6.tgz",
+      "integrity": "sha512-LUORV6bb0TbU4rSC2HoPqUCix1igLrXkRQXWiIyJo2OMzb14kAK/1jsW0mzY6up6w1GrjKQcjc6OwqJdo/zd/g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@svta/cml-cta": "1.0.1",
-        "@svta/cml-structured-field-values": "1.0.1",
-        "@svta/cml-utils": "1.0.1"
+        "@svta/cml-cta": "1.0.6",
+        "@svta/cml-structured-field-values": "1.1.3",
+        "@svta/cml-utils": "1.5.0"
       }
     },
     "node_modules/@svta/cml-cta": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-cta/-/cml-cta-1.0.1.tgz",
-      "integrity": "sha512-jcXqNIPv26bmFxIOFh8/c3+6WLH4qBjKpq9qTQcggDPoHuV1YBydMsJLOnYPDeK8rNMKcAkFLbnDRvyJthu5yw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-cta/-/cml-cta-1.0.6.tgz",
+      "integrity": "sha512-l13/4myTX1EbRd38nY8J1umVY5UdR/nZO6CeKqVLXnMMIayg7/fu0TueZckjTA9Loal55MGK1xbHnXVjz7OUUw==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@svta/cml-structured-field-values": "1.0.1",
-        "@svta/cml-utils": "1.0.1"
+        "@svta/cml-structured-field-values": "1.1.3",
+        "@svta/cml-utils": "1.5.0"
       }
     },
     "node_modules/@svta/cml-dash": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-dash/-/cml-dash-1.0.1.tgz",
-      "integrity": "sha512-lYnD1I7FUbbQND+xICI+kcRaRXuT+whKk27R8m8me5VMVu2sMsAMc7Yui6l9sxw2cBKt8pSETPYRm/1+n4LZkw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-dash/-/cml-dash-1.0.6.tgz",
+      "integrity": "sha512-4XtHYlPrzL/dRe/8XmRQoLnTo9S86tISgrl67eUqKl5MtNTpZBYTncuPrspslPZPZROBBWNrBuepYfYUtU9CKA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@svta/cml-utils": "1.0.1"
+        "@svta/cml-utils": "1.5.0"
       }
     },
     "node_modules/@svta/cml-id3": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-id3/-/cml-id3-1.0.1.tgz",
-      "integrity": "sha512-90fGlL1qRI88CcaB89k6NG6cC3kky4Eu2jwqU4HefqK+S5k2OASUxf8JXkGz+DsdaiY7sh51vGPYdolfBZS7ug==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-id3/-/cml-id3-1.0.6.tgz",
+      "integrity": "sha512-63j8gkAnPOmOBWlp0hIZPvsIioZttdbg6/TgwITqMYbSLYVJ+6QGa/UtIP0I84NsfstANw6QdCn7i8SS08kn1A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@svta/cml-utils": "1.0.1"
+        "@svta/cml-utils": "1.5.0"
       }
     },
     "node_modules/@svta/cml-request": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-request/-/cml-request-1.0.1.tgz",
-      "integrity": "sha512-enL19BuXUjFkDDDF9jdNwUclMNPRsagnjGAetVC7xcmpDMpEx+ZLgsDip6BFNg5p6izSEk/OyujTWW1r8bDNiA==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@svta/cml-request/-/cml-request-1.0.12.tgz",
+      "integrity": "sha512-4sJvnnoNpq58j2mCGP8k+MF6wVy/qa4gbt6kfT1dPIKmn3mPxw+JVfilhcWsUi+peK2yCZxOJJYyHj1cAcQE1w==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@svta/cml-utils": "1.0.1",
-        "@svta/cml-xml": "1.0.1"
+        "@svta/cml-cmcd": "2.3.2",
+        "@svta/cml-utils": "1.5.0",
+        "@svta/cml-xml": "1.1.4"
       }
     },
     "node_modules/@svta/cml-structured-field-values": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-structured-field-values/-/cml-structured-field-values-1.0.1.tgz",
-      "integrity": "sha512-Kibciki59Pon3Pn/sl5uyrbJcSpZQDKqdCfDrokBvOdLoqqcd0oFrkEPsZBiuuIODX1CB80612xe8hopeFDyBA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@svta/cml-structured-field-values/-/cml-structured-field-values-1.1.3.tgz",
+      "integrity": "sha512-XqLzQOTznz6kh/nsSh8dy1kV7GQjL4csG+2U5EvLGhAqNuNUczbVg5EAsDobKDVg8xhdthdXx2UuwM+ZHQCxSg==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@svta/cml-utils": "1.0.1"
+        "@svta/cml-utils": "1.5.0"
       }
     },
     "node_modules/@svta/cml-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-utils/-/cml-utils-1.0.1.tgz",
-      "integrity": "sha512-kso3curTJfp00I1mKFoBliBApjn4aPE+wF8cPucf7TrSDVWZDeLLuF14ASmUE9m7rnrqTTK4878VvmXaXcCCfQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@svta/cml-utils/-/cml-utils-1.5.0.tgz",
+      "integrity": "sha512-JMqclD7Akd+GSJiuaYNUHOP2wNtf/nauKeszlYeivSHfi0Lp3pmSW5PXDvJ2dO4aPmmSOQbF0ztTsW9Vcs2Whw==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -1706,15 +1706,15 @@
       }
     },
     "node_modules/@svta/cml-xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@svta/cml-xml/-/cml-xml-1.0.1.tgz",
-      "integrity": "sha512-11LkJa5kDEcsRMWkVI1ABH3KLCxGoiSVe4kQ293ItVj8ncTTQ7htmCGiJDjS+Cmy35UgF3e/vc0ysJIiWRTx2g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@svta/cml-xml/-/cml-xml-1.1.4.tgz",
+      "integrity": "sha512-jbixqjiJIc16SGxylHwiOzO+DuhkGfuP+fJ9AHeVJKdFDKnabgfCDpnp6dvZpZnjMj4nHvzVtuUV7RISPIwYXw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@svta/cml-utils": "1.0.1"
+        "@svta/cml-utils": "1.5.0"
       }
     },
     "node_modules/@types/argparse": {
@@ -2077,40 +2077,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bcp-47": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
-      "integrity": "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==",
-      "license": "MIT",
-      "dependencies": {
-        "is-alphabetical": "^2.0.0",
-        "is-alphanumerical": "^2.0.0",
-        "is-decimal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/bcp-47-match": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
       "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
       "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/bcp-47-normalize": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/bcp-47-normalize/-/bcp-47-normalize-2.3.0.tgz",
-      "integrity": "sha512-8I/wfzqQvttUFz7HVJgIZ7+dj3vUaIyIxYXaTRP1YWoSDfzt6TUmxaKZeuXR62qBmYr+nvuWINFRl6pZ5DlN4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "bcp-47": "^2.0.0",
-        "bcp-47-match": "^2.0.0"
-      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2286,27 +2257,28 @@
       "license": "MIT"
     },
     "node_modules/dashjs": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/dashjs/-/dashjs-5.1.1.tgz",
-      "integrity": "sha512-BzNXlUgzEjhuZ5M5hlSp1qIyQHZ7NpXAR0loP9DAAFVZj/ntL1DHeZ7qp/L3bvI4rq50X5indkAZQ3zEHWJoCA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dashjs/-/dashjs-5.2.0.tgz",
+      "integrity": "sha512-2W2KHFN53Sk7+rtdnIfSUK/3Oov+hraMTeVZwDOTSCNKM1cQtFiJdblNzRMnl59a/QDseG7JW+PC9mh/B+CMcg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@svta/cml-608": "1.0.1",
-        "@svta/cml-cmcd": "1.0.1",
-        "@svta/cml-cmsd": "1.0.1",
-        "@svta/cml-dash": "1.0.1",
-        "@svta/cml-id3": "1.0.1",
-        "@svta/cml-request": "1.0.1",
-        "@svta/cml-xml": "1.0.1",
+        "@svta/cml-608": "1.0.2",
+        "@svta/cml-cmcd": "2.3.2",
+        "@svta/cml-cmsd": "1.0.6",
+        "@svta/cml-dash": "1.0.6",
+        "@svta/cml-id3": "1.0.6",
+        "@svta/cml-request": "1.0.12",
+        "@svta/cml-xml": "1.1.4",
         "bcp-47-match": "^2.0.3",
-        "bcp-47-normalize": "^2.3.0",
         "codem-isoboxer": "0.3.10",
         "fast-deep-equal": "3.1.3",
-        "html-entities": "^2.5.2",
+        "html-entities": "^2.6.0",
         "imsc": "^1.1.5",
         "localforage": "^1.10.0",
-        "path-browserify": "^1.0.1",
-        "ua-parser-js": "^1.0.37"
+        "path-browserify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/debug": {
@@ -2914,30 +2886,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/is-alphabetical": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
-      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-alphanumerical": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
-      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-alphabetical": "^2.0.0",
-        "is-decimal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/is-arguments": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
@@ -2995,16 +2943,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-decimal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
-      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -4091,32 +4029,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
-      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/undefsafe": {

--- a/packages/player/package-lock.json
+++ b/packages/player/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gcorevideo/player",
-  "version": "2.30.6",
+  "version": "2.30.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gcorevideo/player",
-      "version": "2.30.6",
+      "version": "2.30.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@clappr/core": "^0.13.0",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/G-Core/gcore-videoplayer-js#readme",
   "devDependencies": {
-    "@microsoft/api-documenter": "^7.26.5",
+    "@microsoft/api-documenter": "^7.30.7",
     "@microsoft/api-extractor": "^7.49.1",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-json": "^6.1.0",
@@ -61,13 +61,10 @@
     "@clappr/core": "^0.13.0",
     "@gcorevideo/utils": "^0.7.1",
     "@sentry/types": "^8.47.0",
-    "dashjs": "^5.1.1",
+    "dashjs": "^5.2.0",
     "hls.js": "^1.6.15",
     "human-format": "^1.2.1",
     "mousetrap": "^1.6.5",
     "videojs-vtt.js": "^0.15.5"
-  },
-  "overrides": {
-    "ua-parser-js": "^1.0.0"
   }
 }

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcorevideo/player",
-  "version": "2.30.6",
+  "version": "2.30.7",
   "description": "Gcore JavaScript video player",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
ua-parser-js was a dependency of DASH.js. Since version 5.2.0 it is not anymore